### PR TITLE
Expose the name of the wrapped function

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function wrap(nodule, name, wrapper) {
   }
 
   var original = nodule[name]
-    , wrapped = wrapper(original)
+    , wrapped = wrapper(original, name)
     ;
 
   wrapped.__original = original;

--- a/test/wrap.tap.js
+++ b/test/wrap.tap.js
@@ -14,14 +14,15 @@ var generator = {
 };
 
 test("should wrap safely", function (t) {
-  t.plan(8);
+  t.plan(9);
 
   t.equal(counter, generator.inc, "method is mapped to function");
   t.doesNotThrow(function () { generator.inc(); }, "original funciton works");
   t.equal(1, outsider, "calls have side effects");
 
   var count = 0;
-  function wrapper(original) {
+  function wrapper(original, name) {
+    t.equal(name, 'inc')
     return function () {
       count++;
       var returned = original.apply(this, arguments);


### PR DESCRIPTION
This can be useful when using massWrap to wrap an array of function names. In that case it can be important to know the name of the function currently being wrapped.