### PR TITLE
Support generator functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function isFunction (funktion) {
-  return funktion && {}.toString.call(funktion) === '[object Function]'
+  return funktion && /\[object (Generator)?Function\]/.test({}.toString.call(funktion))
 }
 
 // Default to complaining loudly when things don't go according to plan.


### PR DESCRIPTION
As of V8 5.0, which will be shipping with node v6, generator functions now produce `[object GeneratorFunction]` when `{}.toString` is called on them. This fixes the check. 😸 
