### PR TITLE
Preserve wrapped function enumerability properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
   - "4"
+  - "6"
+  - "8"
+  - "9"
 sudo: false
-before_install:
-  - npm install -g npm@latest

--- a/index.js
+++ b/index.js
@@ -37,11 +37,23 @@ function wrap (nodule, name, wrapper) {
 
   wrapped.__original = original
   wrapped.__unwrap = function () {
-    if (nodule[name] === wrapped) nodule[name] = original
+    if (nodule[name] === wrapped) {
+      Object.defineProperty(nodule, name, {
+        configurable: true,
+        enumerable: nodule.propertyIsEnumerable(name),
+        writable: true,
+        value: original
+      })
+    }
   }
   wrapped.__wrapped = true
 
-  nodule[name] = wrapped
+  Object.defineProperty(nodule, name, {
+    configurable: true,
+    enumerable: nodule.propertyIsEnumerable(name),
+    writable: true,
+    value: wrapped
+  })
 
   return wrapped
 }

--- a/test/wrap.tap.js
+++ b/test/wrap.tap.js
@@ -20,7 +20,7 @@ Object.defineProperty(generator, 'dec', {
 })
 
 test('should wrap safely', function (t) {
-  t.plan(11)
+  t.plan(12)
 
   t.equal(counter, generator.inc, 'method is mapped to function')
   t.doesNotThrow(function () { generator.inc() }, 'original function works')
@@ -45,6 +45,8 @@ test('should wrap safely', function (t) {
   t.equal(2, outsider, 'original function has still been called')
   t.ok(generator.propertyIsEnumerable('inc'),
     'wrapped enumerable property is still enumerable')
+  t.equal(Object.keys(generator.inc).length, 0,
+    'wrapped object has no additional properties')
 
   shimmer.wrap(generator, 'dec', function (original) {
     return function () {


### PR DESCRIPTION
Monkeypatching the `http` module to preserve context in client-side response event listeners (using `continuation-local-storage`) causes the behavior of `got` v7+ to change. This PR, in conjunction with https://github.com/othiym23/emitter-listener/pull/4, should fix that.

## Repro

```js
const cls = require('continuation-local-storage');
const express = require('express');
const fs = require('fs');
const http = require('http');
const mimicResponse = require('mimic-response'); // got dependency
const PassThrough = require('stream').PassThrough;
const zlib = require('zlib');

const namespace = cls.createNamespace('a');

const app = express();

// send the local package.json file gzipped.
app.get('/', (req, res) => {
  res.set('content-encoding', 'gzip');
  const pjson = fs.createReadStream('package.json');
  pjson.pipe(zlib.createGzip()).pipe(res);
});

const server = app.listen(3000, () => {
  http.get('http://localhost:3000', res => {
    // Using cls to bind context to event listeners adds additional enumerable properties.
    const resPropsBeforeBind = Object.keys(res);
    // We bind the emitter here. [1]
    namespace.bindEmitter(res);
    const resPropsAfterBind = Object.keys(res);
    // outputs: [ 'wrap@before', 'addListener', 'on', 'emit', '__unwrap', '__wrapped' ]
    console.log(resPropsAfterBind.filter(prop => resPropsBeforeBind.indexOf(prop) === -1));

    // This is the snippet of code that causes things to fail.
    // It's part of 'got'.
    // (More accurately, it's part of the 'mimic-response', which is part of
    // 'decompress-response', which is part of 'got'.)
    // mimicResponse replicates enumerable properties on a target object
    // (2nd argument), which makes it look like a source object (1st argument).
    const stream = new PassThrough();
    mimicResponse(res, stream);
    res = res.pipe(zlib.createUnzip()).pipe(stream);

    const buffers = [];
    res.on('data', data => buffers.push(data));
    res.on('end', () => {
      // Without [1], this shows the plain-text file correctly.
      // With [1], this shows the still-compressed data.
      console.log(buffers.join(''));
      server.close();
    });
  });
});
```

### Explanation

Currently, if `shimmer` is used to monkeypatch an unenumerable function property of an object, the replaced function will always be enumerable. This affects any code that enumerates through the properties of that object. For example, functions like `on` and `addListener` on the `EventEmitter` object are un-enumerable, and using `continuation-local-storage` to wrap it made them enumerable. This in turn caused the `got` library to have unexpected behavior, because it (through its `mimic-response` dependency) iterates through enumerable properties of an `http.IncomingMessage` object.

## Changes

This PR changes `wrap` so that wrapped functions inherit their enumerability from the original function that they wrap.

The use of `__wrapped` (etc) causes similar problems, so I made them unenumerable as well.