### PR TITLE
Use typeof in isFunction().

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function isFunction (funktion) {
-  return funktion && {}.toString.call(funktion) === '[object Function]'
+  return typeof funktion === 'function'
 }
 
 // Default to complaining loudly when things don't go according to plan.


### PR DESCRIPTION
shimmer does not wrap when the function to be wrapped is async, because `{}.toString.call(funktion)` returns `[object AsyncFunction]`.

I have changed the test to just use `typeof funktion`. I considered verifying that they are both the same type of function, i.e., async or not, but my wrapper is technically not async even though it returns a promise.

I see the other PR from qard but it doesn't seem like adding checks for all forms of functions is useful. The patch author already has to know that the wrapper function supplied is a valid replacement for the original function. SIgnature, return values, etc. The type of function is just another item that the patch author must get right.