### PR TITLE
fix isFunction

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function isFunction (funktion) {
-  return funktion && {}.toString.call(funktion) === '[object Function]'
+  return funktion && ({}.toString.call(funktion) === '[object Function]' || {}.toString.call(funktion) === '[object AsyncFunction]' || {}.toString.call(funktion) === '[object GeneratorFunction]')
 }
 
 // Default to complaining loudly when things don't go according to plan.


### PR DESCRIPTION
With the current implementation the isFunction returns:
```
isFunction(()=>{})
true
isFunction(async ()=>{})
false
isFunction(function* (){})
false
```
After the changes:
```
isFunction(()=>{})
true
isFunction(async ()=>{})
true
isFunction(function* (){})
true
```